### PR TITLE
(fix) TypeError: 'module' object is not callable

### DIFF
--- a/pyinstaller_setuptools/__init__.py
+++ b/pyinstaller_setuptools/__init__.py
@@ -1,1 +1,1 @@
-from setup import setup
+from .setup import setup


### PR DESCRIPTION
Changed implicit import to explicit relative import for python 3 support
Without this change, importing the package is impossible